### PR TITLE
Adding an "info" metric

### DIFF
--- a/includes/classes/Default_Metrics_Loader.php
+++ b/includes/classes/Default_Metrics_Loader.php
@@ -3,6 +3,7 @@
 namespace WP_Prometheus_Metrics;
 
 use WP_Prometheus_Metrics\metrics\Database_Size_Metric;
+use WP_Prometheus_Metrics\metrics\Info_Metric;
 use WP_Prometheus_Metrics\metrics\Options_Autoloaded_Count_Metric;
 use WP_Prometheus_Metrics\metrics\Options_Autoloaded_Size_Metric;
 use WP_Prometheus_Metrics\metrics\Pending_Updates_Metric;
@@ -29,6 +30,7 @@ class Default_Metrics_Loader
     {
         if (!$this->metrics_loaded) {
             new Database_Size_Metric();
+            new Info_Metric();
             new Options_Autoloaded_Count_Metric();
             new Options_Autoloaded_Size_Metric();
             new Pending_Updates_Metric();

--- a/includes/classes/metrics/Info_Metric.php
+++ b/includes/classes/metrics/Info_Metric.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_Prometheus_Metrics\metrics;
+
+
+/**
+ * A metric that gives information about the WordPress environment.
+ */
+class Info_Metric extends Abstract_Gauge_Metric
+{
+    public function __construct()
+    {
+        parent::__construct('info');
+    }
+
+    public function get_metric_labels(): array
+    {
+        global $wp_db_version;
+
+        return array_merge(
+            parent::get_metric_labels(),
+            [
+                'version' => get_bloginfo('version'),
+                'db_version' => $wp_db_version,
+            ]
+        );
+    }
+
+    function get_metric_value()
+    {
+        // This metric as no value, the interesting part is in it's labels.
+        // Returning a standard 1 value here.
+        return 1;
+    }
+
+    function get_help_text(): string
+    {
+        return _x('Information about the WordPress environment', 'Metric Help Text', 'prometheus-metrics-for-wp');
+    }
+}


### PR DESCRIPTION
Here is an implementation for new `wp_info` metric to export WordPress code and database versions as talked in #15.